### PR TITLE
fix: Make gRPC reflection callable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/nats-io/nats.go v1.25.0
 	github.com/onsi/ginkgo/v2 v2.9.5
 	github.com/onsi/gomega v1.27.7
-	github.com/planetscale/vtprotobuf v0.4.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.41.1
 	go.opentelemetry.io/otel v1.15.1
 	go.opentelemetry.io/otel/sdk v1.15.1

--- a/go.sum
+++ b/go.sum
@@ -313,8 +313,6 @@ github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsK
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/planetscale/vtprotobuf v0.4.0 h1:NEI+g4woRaAZgeZ3sAvbtyvMBRjIv5kE7EWYQ8m4JwY=
-github.com/planetscale/vtprotobuf v0.4.0/go.mod h1:wm1N3qk9G/4+VM1WhpkLbvY/d8+0PbwYYpP5P5VhTks=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=

--- a/internal/api/codec.go
+++ b/internal/api/codec.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// vtMessage is the VT specific interface for protobuf messages.
+type vtMessage interface {
+	MarshalVT() ([]byte, error)
+	UnmarshalVT([]byte) error
+}
+
+// codec is a custom implementation of a gRPC codec. It supports both
+// protobuf and VTprotobuf messages.
+type codec struct {
+}
+
+func (c codec) Marshal(v interface{}) ([]byte, error) {
+	if vt, ok := v.(vtMessage); ok {
+		return vt.MarshalVT()
+	}
+
+	if pb, ok := v.(proto.Message); ok {
+		return proto.Marshal(pb)
+	}
+
+	return nil, fmt.Errorf("unsupported type: %T", v)
+}
+
+func (c codec) Unmarshal(data []byte, v interface{}) error {
+	if vt, ok := v.(vtMessage); ok {
+		return vt.UnmarshalVT(data)
+	}
+
+	if pb, ok := v.(proto.Message); ok {
+		return proto.Unmarshal(data, pb)
+	}
+
+	return fmt.Errorf("unsupported type: %T", v)
+}
+
+func (c codec) Name() string {
+	return "proto"
+}

--- a/internal/api/module.go
+++ b/internal/api/module.go
@@ -2,14 +2,13 @@ package api
 
 import (
 	"github.com/levelfourab/sprout-go"
-	"github.com/planetscale/vtprotobuf/codec/grpc"
 	"go.uber.org/fx"
 	"google.golang.org/grpc/encoding"
 	_ "google.golang.org/grpc/encoding/proto" // For vtprotobuf
 )
 
 func init() {
-	encoding.RegisterCodec(grpc.Codec{})
+	encoding.RegisterCodec(codec{})
 }
 
 type Config struct {


### PR DESCRIPTION
This implements a custom gRPC codec that supports both Protobuf and vtprotobuf messages.