### PR TITLE
refactor: Update to new JetStream API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.5
 	github.com/levelfourab/sprout-go v0.10.1
 	github.com/nats-io/nats-server/v2 v2.9.17
-	github.com/nats-io/nats.go v1.25.0
+	github.com/nats-io/nats.go v1.28.0
 	github.com/onsi/ginkgo/v2 v2.9.5
 	github.com/onsi/gomega v1.27.7
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -290,8 +290,8 @@ github.com/nats-io/jwt/v2 v2.4.1/go.mod h1:24BeQtRwxRV8ruvC4CojXlx/WQ/VjuwlYiH+v
 github.com/nats-io/nats-server/v2 v2.9.17 h1:gFpUQ3hqIDJrnqog+Bl5vaXg+RhhYEZIElasEuRn2tw=
 github.com/nats-io/nats-server/v2 v2.9.17/go.mod h1:eQysm3xDZmIjfkjr7DuD9DjRFpnxQc2vKVxtEg0Dp6s=
 github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzEE/Zbp4w=
-github.com/nats-io/nats.go v1.25.0 h1:t5/wCPGciR7X3Mu8QOi4jiJaXaWM8qtkLu4lzGZvYHE=
-github.com/nats-io/nats.go v1.25.0/go.mod h1:D2WALIhz7V8M0pH8Scx8JZXlg6Oqz5VG+nQkK8nJdvg=
+github.com/nats-io/nats.go v1.28.0 h1:Th4G6zdsz2d0OqXdfzKLClo6bOfoI/b1kInhRtFIy5c=
+github.com/nats-io/nats.go v1.28.0/go.mod h1:XpbWUlOElGwTYbMR7imivs7jJj9GtK7ypv321Wp6pjc=
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.4.4 h1:xvBJ8d69TznjcQl9t6//Q5xXuVhyYiSos6RPtvQNTwA=
 github.com/nats-io/nkeys v0.4.4/go.mod h1:XUkxdLPTufzlihbamfzQ7mw/VGx6ObUs+0bN5sNvt64=

--- a/internal/events/flowcontrol/control.go
+++ b/internal/events/flowcontrol/control.go
@@ -100,6 +100,11 @@ func (fc *FlowControl) GetBatchSize() int {
 	return currentLimit - fc.tracker.Count()
 }
 
+func (fc *FlowControl) WaitUntilAvailable() {
+	currentLimit := int(atomic.LoadInt64(&fc.currentProcessingLimit))
+	fc.tracker.WaitUntilLessThan(currentLimit)
+}
+
 func (fc *FlowControl) updateProcessingLimit() {
 	acked := atomic.SwapInt64(&fc.eventsAckedInLastInterval, 0)
 	rejected := atomic.SwapInt64(&fc.eventsRejectedInLastInterval, 0)

--- a/internal/events/manager.go
+++ b/internal/events/manager.go
@@ -3,6 +3,7 @@ package events
 import (
 	"github.com/cockroachdb/errors"
 	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -13,7 +14,7 @@ type Manager struct {
 	tracer        trace.Tracer
 	w3cPropagator propagation.TextMapPropagator
 
-	jetStream nats.JetStreamContext
+	js jetstream.JetStream
 }
 
 func NewManager(
@@ -21,7 +22,7 @@ func NewManager(
 	tracer trace.Tracer,
 	conn *nats.Conn,
 ) (*Manager, error) {
-	js, err := conn.JetStream()
+	js, err := jetstream.New(conn)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create JetStream channel")
 	}
@@ -30,7 +31,7 @@ func NewManager(
 		logger:        logger,
 		tracer:        tracer,
 		w3cPropagator: propagation.TraceContext{},
-		jetStream:     js,
+		js:            js,
 	}
 
 	return m, nil

--- a/internal/events/module_test.go
+++ b/internal/events/module_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.opentelemetry.io/otel"
@@ -55,10 +56,10 @@ func GetJetStream() nats.JetStreamContext {
 	return js
 }
 
-func createManagerAndJetStream() (*events.Manager, nats.JetStreamContext) {
+func createManagerAndJetStream() (*events.Manager, jetstream.JetStream) {
 	natsConn := GetNATS()
 
-	js, err := natsConn.JetStream()
+	js, err := jetstream.New(natsConn)
 	Expect(err).ToNot(HaveOccurred())
 
 	manager, err := events.NewManager(

--- a/internal/events/streams_test.go
+++ b/internal/events/streams_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 	"windshift/service/internal/events"
 
-	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -14,29 +14,29 @@ import (
 
 var _ = Describe("Streams", func() {
 	var manager *events.Manager
-	var js nats.JetStreamContext
+	var js jetstream.JetStream
 
 	BeforeEach(func() {
 		manager, js = createManagerAndJetStream()
 	})
 
 	It("can create a stream", func(ctx context.Context) {
-		_, err := js.StreamInfo("test")
-		Expect(err).To(MatchError(nats.ErrStreamNotFound))
+		_, err := js.Stream(ctx, "test")
+		Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 		_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 			Name: "test",
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		info, err := js.StreamInfo("test")
+		stream, err := js.Stream(ctx, "test")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(info.Config.Name).To(Equal("test"))
+		Expect(stream.CachedInfo().Config.Name).To(Equal("test"))
 	})
 
 	It("parallel requests to create stream succeed", func(ctx context.Context) {
-		_, err := js.StreamInfo("test")
-		Expect(err).To(MatchError(nats.ErrStreamNotFound))
+		_, err := js.Stream(ctx, "test")
+		Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 		tries := 2
 		wg := &sync.WaitGroup{}
@@ -60,17 +60,17 @@ var _ = Describe("Streams", func() {
 	})
 
 	It("can update an existing stream", func(ctx context.Context) {
-		_, err := js.StreamInfo("test")
-		Expect(err).To(MatchError(nats.ErrStreamNotFound))
+		_, err := js.Stream(ctx, "test")
+		Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 		_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 			Name: "test",
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		info, err := js.StreamInfo("test")
+		stream, err := js.Stream(ctx, "test")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(info.Config.Name).To(Equal("test"))
+		Expect(stream.CachedInfo().Config.Name).To(Equal("test"))
 
 		_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 			Name: "test",
@@ -81,8 +81,8 @@ var _ = Describe("Streams", func() {
 	Describe("Sources", func() {
 		Context("Subjects", func() {
 			It("can create stream with single subject", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 					Name: "test",
@@ -92,15 +92,15 @@ var _ = Describe("Streams", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 
-				info, err := js.StreamInfo("test")
+				stream, err := js.Stream(ctx, "test")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.Config.Name).To(Equal("test"))
-				Expect(info.Config.Subjects).To(ContainElement("test"))
+				Expect(stream.CachedInfo().Config.Name).To(Equal("test"))
+				Expect(stream.CachedInfo().Config.Subjects).To(ContainElement("test"))
 			})
 
 			It("can update stream with single subject", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 					Name: "test",
@@ -118,16 +118,16 @@ var _ = Describe("Streams", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 
-				info, err := js.StreamInfo("test")
+				stream, err := js.Stream(ctx, "test")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.Config.Name).To(Equal("test"))
-				Expect(info.Config.Subjects).To(ContainElement("test2"))
-				Expect(info.Config.Subjects).ToNot(ContainElement("test"))
+				Expect(stream.CachedInfo().Config.Name).To(Equal("test"))
+				Expect(stream.CachedInfo().Config.Subjects).To(ContainElement("test2"))
+				Expect(stream.CachedInfo().Config.Subjects).ToNot(ContainElement("test"))
 			})
 
 			It("can create stream with multiple subjects", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 					Name: "test",
@@ -138,16 +138,16 @@ var _ = Describe("Streams", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 
-				info, err := js.StreamInfo("test")
+				stream, err := js.Stream(ctx, "test")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.Config.Name).To(Equal("test"))
-				Expect(info.Config.Subjects).To(ContainElement("test"))
-				Expect(info.Config.Subjects).To(ContainElement("test.*"))
+				Expect(stream.CachedInfo().Config.Name).To(Equal("test"))
+				Expect(stream.CachedInfo().Config.Subjects).To(ContainElement("test"))
+				Expect(stream.CachedInfo().Config.Subjects).To(ContainElement("test.*"))
 			})
 
 			It("can remove a subject from a stream", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 					Name: "test",
@@ -166,15 +166,15 @@ var _ = Describe("Streams", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 
-				info, err := js.StreamInfo("test")
+				stream, err := js.Stream(ctx, "test")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.Config.Subjects).To(ContainElement("test"))
-				Expect(info.Config.Subjects).ToNot(ContainElement("test.*"))
+				Expect(stream.CachedInfo().Config.Subjects).To(ContainElement("test"))
+				Expect(stream.CachedInfo().Config.Subjects).ToNot(ContainElement("test.*"))
 			})
 
 			It("can add a subject to a stream", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 					Name: "test",
 					Subjects: []string{
@@ -190,15 +190,15 @@ var _ = Describe("Streams", func() {
 					},
 				})
 				Expect(err).ToNot(HaveOccurred())
-				info, err := js.StreamInfo("test")
+				stream, err := js.Stream(ctx, "test")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.Config.Subjects).To(ContainElement("test"))
-				Expect(info.Config.Subjects).To(ContainElement("test.*"))
+				Expect(stream.CachedInfo().Config.Subjects).To(ContainElement("test"))
+				Expect(stream.CachedInfo().Config.Subjects).To(ContainElement("test.*"))
 			})
 
 			It("can create stream with multiple subjects and wildcards", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 					Name: "test",
@@ -210,18 +210,18 @@ var _ = Describe("Streams", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 
-				info, err := js.StreamInfo("test")
+				stream, err := js.Stream(ctx, "test")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.Config.Subjects).To(ContainElement("test"))
-				Expect(info.Config.Subjects).To(ContainElement("test.1.*"))
-				Expect(info.Config.Subjects).To(ContainElement("test.2.*"))
+				Expect(stream.CachedInfo().Config.Subjects).To(ContainElement("test"))
+				Expect(stream.CachedInfo().Config.Subjects).To(ContainElement("test.1.*"))
+				Expect(stream.CachedInfo().Config.Subjects).To(ContainElement("test.2.*"))
 			})
 		})
 
 		Context("mirroring streams", func() {
 			It("can create a mirror of a stream", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 					Name: "test",
@@ -236,15 +236,15 @@ var _ = Describe("Streams", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 
-				info, err := js.StreamInfo("test-mirror")
+				stream, err := js.Stream(ctx, "test-mirror")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.Config.Mirror).ToNot(BeNil())
-				Expect(info.Config.Mirror.Name).To(Equal("test"))
+				Expect(stream.CachedInfo().Config.Mirror).ToNot(BeNil())
+				Expect(stream.CachedInfo().Config.Mirror.Name).To(Equal("test"))
 			})
 
 			It("a mirror of a stream does not copy old data", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				// Create the source stream
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
@@ -271,14 +271,14 @@ var _ = Describe("Streams", func() {
 				time.Sleep(200 * time.Millisecond)
 
 				// Verify that the mirror stream has no messages
-				info, err := js.StreamInfo("test-mirror")
+				stream, err := js.Stream(ctx, "test-mirror")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.State.Msgs).To(Equal(uint64(0)))
+				Expect(stream.CachedInfo().State.Msgs).To(Equal(uint64(0)))
 			})
 
 			It("a mirror of a stream copies new data", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				// Create the source stream
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
@@ -305,14 +305,14 @@ var _ = Describe("Streams", func() {
 				time.Sleep(200 * time.Millisecond)
 
 				// Verify that the mirror stream has the message
-				info, err := js.StreamInfo("test-mirror")
+				stream, err := js.Stream(ctx, "test-mirror")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.State.Msgs).To(Equal(uint64(1)))
+				Expect(stream.CachedInfo().State.Msgs).To(Equal(uint64(1)))
 			})
 
 			It("can create a mirror of a stream with a start time", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 					Name: "test",
@@ -331,16 +331,16 @@ var _ = Describe("Streams", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 
-				info, err := js.StreamInfo("test-mirror")
+				stream, err := js.Stream(ctx, "test-mirror")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.Config.Mirror).ToNot(BeNil())
-				Expect(info.Config.Mirror.Name).To(Equal("test"))
-				Expect(*info.Config.Mirror.OptStartTime).To(BeTemporally("~", time))
+				Expect(stream.CachedInfo().Config.Mirror).ToNot(BeNil())
+				Expect(stream.CachedInfo().Config.Mirror.Name).To(Equal("test"))
+				Expect(*stream.CachedInfo().Config.Mirror.OptStartTime).To(BeTemporally("~", time))
 			})
 
 			It("a mirror of a stream with a start time copies old data", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 					Name: "test",
@@ -370,14 +370,14 @@ var _ = Describe("Streams", func() {
 				time.Sleep(200 * time.Millisecond)
 
 				// Verify that the mirror stream has the message
-				info, err := js.StreamInfo("test-mirror")
+				stream, err := js.Stream(ctx, "test-mirror")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.State.Msgs).To(Equal(uint64(1)))
+				Expect(stream.CachedInfo().State.Msgs).To(Equal(uint64(1)))
 			})
 
 			It("a mirror of a stream with a start time does not copy too old data", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 					Name: "test",
@@ -409,14 +409,14 @@ var _ = Describe("Streams", func() {
 				time.Sleep(200 * time.Millisecond)
 
 				// Verify that the mirror stream does not have the message
-				info, err := js.StreamInfo("test-mirror")
+				stream, err := js.Stream(ctx, "test-mirror")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.State.Msgs).To(Equal(uint64(0)))
+				Expect(stream.CachedInfo().State.Msgs).To(Equal(uint64(0)))
 			})
 
 			It("can create a mirror of a stream with a start id", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 					Name: "test",
@@ -434,16 +434,16 @@ var _ = Describe("Streams", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 
-				info, err := js.StreamInfo("test-mirror")
+				stream, err := js.Stream(ctx, "test-mirror")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.Config.Mirror).ToNot(BeNil())
-				Expect(info.Config.Mirror.Name).To(Equal("test"))
-				Expect(info.Config.Mirror.OptStartSeq).To(Equal(uint64(1)))
+				Expect(stream.CachedInfo().Config.Mirror).ToNot(BeNil())
+				Expect(stream.CachedInfo().Config.Mirror.Name).To(Equal("test"))
+				Expect(stream.CachedInfo().Config.Mirror.OptStartSeq).To(Equal(uint64(1)))
 			})
 
 			It("can create a mirror of a stream with a start id and it will copy data from id", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				// Create the source stream
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
@@ -478,14 +478,14 @@ var _ = Describe("Streams", func() {
 				time.Sleep(100 * time.Millisecond)
 
 				// Verify that the mirror stream has the message
-				info, err := js.StreamInfo("test-mirror")
+				stream, err := js.Stream(ctx, "test-mirror")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.State.Msgs).To(Equal(uint64(1)))
+				Expect(stream.CachedInfo().State.Msgs).To(Equal(uint64(1)))
 			})
 
 			It("can create a mirror of a stream with a start id and it will receive new events", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 					Name: "test",
@@ -512,14 +512,14 @@ var _ = Describe("Streams", func() {
 				time.Sleep(100 * time.Millisecond)
 
 				// Verify that the mirror stream has the message
-				info, err := js.StreamInfo("test-mirror")
+				stream, err := js.Stream(ctx, "test-mirror")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.State.Msgs).To(Equal(uint64(1)))
+				Expect(stream.CachedInfo().State.Msgs).To(Equal(uint64(1)))
 			})
 
 			It("can create a mirror of a stream starting at the first event", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 					Name: "test",
@@ -537,16 +537,16 @@ var _ = Describe("Streams", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 
-				info, err := js.StreamInfo("test-mirror")
+				stream, err := js.Stream(ctx, "test-mirror")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.Config.Mirror).ToNot(BeNil())
-				Expect(info.Config.Mirror.Name).To(Equal("test"))
-				Expect(info.Config.Mirror.OptStartSeq).To(Equal(uint64(0)))
+				Expect(stream.CachedInfo().Config.Mirror).ToNot(BeNil())
+				Expect(stream.CachedInfo().Config.Mirror.Name).To(Equal("test"))
+				Expect(stream.CachedInfo().Config.Mirror.OptStartSeq).To(Equal(uint64(0)))
 			})
 
 			It("can create a mirror of a stream starting at the first event and it will receive old data", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				// Create the source stream
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
@@ -576,16 +576,16 @@ var _ = Describe("Streams", func() {
 				time.Sleep(100 * time.Millisecond)
 
 				// Verify that the mirror stream has the message
-				info, err := js.StreamInfo("test-mirror")
+				stream, err := js.Stream(ctx, "test-mirror")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.State.Msgs).To(Equal(uint64(1)))
+				Expect(stream.CachedInfo().State.Msgs).To(Equal(uint64(1)))
 			})
 		})
 
 		Context("Non-mirrored stream sources", func() {
 			It("can have source of another stream", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 					Name: "test",
@@ -602,15 +602,15 @@ var _ = Describe("Streams", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 
-				info, err := js.StreamInfo("test2")
+				stream, err := js.Stream(ctx, "test2")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.Config.Sources).To(HaveLen(1))
-				Expect(info.Config.Sources[0].Name).To(Equal("test"))
+				Expect(stream.CachedInfo().Config.Sources).To(HaveLen(1))
+				Expect(stream.CachedInfo().Config.Sources[0].Name).To(Equal("test"))
 			})
 
 			It("can have multiple sources of another stream", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 					Name: "test",
@@ -635,16 +635,16 @@ var _ = Describe("Streams", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 
-				info, err := js.StreamInfo("test3")
+				stream, err := js.Stream(ctx, "test3")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.Config.Sources).To(HaveLen(2))
-				Expect(info.Config.Sources[0].Name).To(Equal("test"))
-				Expect(info.Config.Sources[1].Name).To(Equal("test2"))
+				Expect(stream.CachedInfo().Config.Sources).To(HaveLen(2))
+				Expect(stream.CachedInfo().Config.Sources[0].Name).To(Equal("test"))
+				Expect(stream.CachedInfo().Config.Sources[1].Name).To(Equal("test2"))
 			})
 
 			It("does not copy old data by default", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 					Name: "test",
@@ -669,14 +669,14 @@ var _ = Describe("Streams", func() {
 
 				time.Sleep(200 * time.Millisecond)
 
-				info, err := js.StreamInfo("test2")
+				stream, err := js.Stream(ctx, "test2")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.State.Msgs).To(Equal(uint64(0)))
+				Expect(stream.CachedInfo().State.Msgs).To(Equal(uint64(0)))
 			})
 
 			It("can copy from specific id of another stream", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				// Create the source stream
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
@@ -712,14 +712,14 @@ var _ = Describe("Streams", func() {
 
 				time.Sleep(200 * time.Millisecond)
 
-				info, err := js.StreamInfo("test2")
+				stream, err := js.Stream(ctx, "test2")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.State.Msgs).To(Equal(uint64(1)))
+				Expect(stream.CachedInfo().State.Msgs).To(Equal(uint64(1)))
 			})
 
 			It("can copy from specific time of another stream", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				// Create the source stream
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
@@ -759,14 +759,14 @@ var _ = Describe("Streams", func() {
 
 				time.Sleep(200 * time.Millisecond)
 
-				info, err := js.StreamInfo("test2")
+				stream, err := js.Stream(ctx, "test2")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.State.Msgs).To(Equal(uint64(1)))
+				Expect(stream.CachedInfo().State.Msgs).To(Equal(uint64(1)))
 			})
 
 			It("can copy from start of other stream", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				// Create the source stream
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
@@ -797,17 +797,17 @@ var _ = Describe("Streams", func() {
 
 				time.Sleep(200 * time.Millisecond)
 
-				info, err := js.StreamInfo("test2")
+				stream, err := js.Stream(ctx, "test2")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.State.Msgs).To(Equal(uint64(1)))
+				Expect(stream.CachedInfo().State.Msgs).To(Equal(uint64(1)))
 			})
 		})
 	})
 
 	Describe("Retention policies", func() {
 		It("can create stream with max age", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:   "test",
@@ -815,15 +815,15 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.Name).To(Equal("test"))
-			Expect(info.Config.MaxAge).To(Equal(1 * time.Hour))
+			Expect(stream.CachedInfo().Config.Name).To(Equal("test"))
+			Expect(stream.CachedInfo().Config.MaxAge).To(Equal(1 * time.Hour))
 		})
 
 		It("can update stream without max age and set max age", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name: "test",
@@ -836,15 +836,15 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.Name).To(Equal("test"))
-			Expect(info.Config.MaxAge).To(Equal(1 * time.Hour))
+			Expect(stream.CachedInfo().Config.Name).To(Equal("test"))
+			Expect(stream.CachedInfo().Config.MaxAge).To(Equal(1 * time.Hour))
 		})
 
 		It("can update stream and change max age", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:   "test",
@@ -858,15 +858,15 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.Name).To(Equal("test"))
-			Expect(info.Config.MaxAge).To(Equal(2 * time.Hour))
+			Expect(stream.CachedInfo().Config.Name).To(Equal("test"))
+			Expect(stream.CachedInfo().Config.MaxAge).To(Equal(2 * time.Hour))
 		})
 
 		It("can remove max age from stream", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:   "test",
@@ -879,14 +879,14 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.MaxAge).To(Equal(0 * time.Second))
+			Expect(stream.CachedInfo().Config.MaxAge).To(Equal(0 * time.Second))
 		})
 
 		It("can create stream with max messages", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:    "test",
@@ -894,15 +894,15 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.Name).To(Equal("test"))
-			Expect(info.Config.MaxMsgs).To(Equal(int64(100)))
+			Expect(stream.CachedInfo().Config.Name).To(Equal("test"))
+			Expect(stream.CachedInfo().Config.MaxMsgs).To(Equal(int64(100)))
 		})
 
 		It("can update stream without max messages and set max messages", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name: "test",
@@ -915,15 +915,15 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.Name).To(Equal("test"))
-			Expect(info.Config.MaxMsgs).To(Equal(int64(100)))
+			Expect(stream.CachedInfo().Config.Name).To(Equal("test"))
+			Expect(stream.CachedInfo().Config.MaxMsgs).To(Equal(int64(100)))
 		})
 
 		It("can update stream and change max messages", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:    "test",
@@ -937,15 +937,15 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.Name).To(Equal("test"))
-			Expect(info.Config.MaxMsgs).To(Equal(int64(200)))
+			Expect(stream.CachedInfo().Config.Name).To(Equal("test"))
+			Expect(stream.CachedInfo().Config.MaxMsgs).To(Equal(int64(200)))
 		})
 
 		It("can remove max messages from stream", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:    "test",
@@ -958,14 +958,14 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.MaxMsgs).To(Equal(int64(-1)))
+			Expect(stream.CachedInfo().Config.MaxMsgs).To(Equal(int64(-1)))
 		})
 
 		It("can create stream with max bytes", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:     "test",
@@ -973,15 +973,15 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.Name).To(Equal("test"))
-			Expect(info.Config.MaxBytes).To(Equal(int64(100)))
+			Expect(stream.CachedInfo().Config.Name).To(Equal("test"))
+			Expect(stream.CachedInfo().Config.MaxBytes).To(Equal(int64(100)))
 		})
 
 		It("can update stream without max bytes and set max bytes", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name: "test",
@@ -994,15 +994,15 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.Name).To(Equal("test"))
-			Expect(info.Config.MaxBytes).To(Equal(int64(100)))
+			Expect(stream.CachedInfo().Config.Name).To(Equal("test"))
+			Expect(stream.CachedInfo().Config.MaxBytes).To(Equal(int64(100)))
 		})
 
 		It("can update stream and change max bytes", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:     "test",
@@ -1016,15 +1016,15 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.Name).To(Equal("test"))
-			Expect(info.Config.MaxBytes).To(Equal(int64(200)))
+			Expect(stream.CachedInfo().Config.Name).To(Equal("test"))
+			Expect(stream.CachedInfo().Config.MaxBytes).To(Equal(int64(200)))
 		})
 
 		It("can remove max bytes from stream", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:     "test",
@@ -1037,14 +1037,14 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.MaxBytes).To(Equal(int64(-1)))
+			Expect(stream.CachedInfo().Config.MaxBytes).To(Equal(int64(-1)))
 		})
 
 		It("can create stream with max age and max messages", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:    "test",
@@ -1053,16 +1053,16 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.Name).To(Equal("test"))
-			Expect(info.Config.MaxAge).To(Equal(1 * time.Hour))
-			Expect(info.Config.MaxMsgs).To(Equal(int64(100)))
+			Expect(stream.CachedInfo().Config.Name).To(Equal("test"))
+			Expect(stream.CachedInfo().Config.MaxAge).To(Equal(1 * time.Hour))
+			Expect(stream.CachedInfo().Config.MaxMsgs).To(Equal(int64(100)))
 		})
 
 		It("can update stream with max age and max messages", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:    "test",
@@ -1078,15 +1078,15 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.MaxAge).To(Equal(2 * time.Hour))
-			Expect(info.Config.MaxMsgs).To(Equal(int64(200)))
+			Expect(stream.CachedInfo().Config.MaxAge).To(Equal(2 * time.Hour))
+			Expect(stream.CachedInfo().Config.MaxMsgs).To(Equal(int64(200)))
 		})
 
 		It("can remove max age and max messages from stream", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:    "test",
@@ -1100,15 +1100,15 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.MaxAge).To(Equal(0 * time.Second))
-			Expect(info.Config.MaxMsgs).To(Equal(int64(-1)))
+			Expect(stream.CachedInfo().Config.MaxAge).To(Equal(0 * time.Second))
+			Expect(stream.CachedInfo().Config.MaxMsgs).To(Equal(int64(-1)))
 		})
 
 		It("can create stream with max age and add max messages", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:   "test",
@@ -1123,15 +1123,15 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.MaxAge).To(Equal(1 * time.Hour))
-			Expect(info.Config.MaxMsgs).To(Equal(int64(100)))
+			Expect(stream.CachedInfo().Config.MaxAge).To(Equal(1 * time.Hour))
+			Expect(stream.CachedInfo().Config.MaxMsgs).To(Equal(int64(100)))
 		})
 
 		It("can create stream with max age and replace with max messages", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:   "test",
@@ -1145,15 +1145,15 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.MaxAge).To(Equal(0 * time.Second))
-			Expect(info.Config.MaxMsgs).To(Equal(int64(100)))
+			Expect(stream.CachedInfo().Config.MaxAge).To(Equal(0 * time.Second))
+			Expect(stream.CachedInfo().Config.MaxMsgs).To(Equal(int64(100)))
 		})
 
 		It("can create stream with max age and max bytes", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:     "test",
@@ -1162,15 +1162,15 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.MaxAge).To(Equal(1 * time.Hour))
-			Expect(info.Config.MaxBytes).To(Equal(int64(100)))
+			Expect(stream.CachedInfo().Config.MaxAge).To(Equal(1 * time.Hour))
+			Expect(stream.CachedInfo().Config.MaxBytes).To(Equal(int64(100)))
 		})
 
 		It("can update stream with max age and max bytes", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:     "test",
@@ -1186,15 +1186,15 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.MaxAge).To(Equal(2 * time.Hour))
-			Expect(info.Config.MaxBytes).To(Equal(int64(200)))
+			Expect(stream.CachedInfo().Config.MaxAge).To(Equal(2 * time.Hour))
+			Expect(stream.CachedInfo().Config.MaxBytes).To(Equal(int64(200)))
 		})
 
 		It("can remove max age and max bytes from stream", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:     "test",
@@ -1208,15 +1208,15 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.MaxAge).To(Equal(0 * time.Second))
-			Expect(info.Config.MaxBytes).To(Equal(int64(-1)))
+			Expect(stream.CachedInfo().Config.MaxAge).To(Equal(0 * time.Second))
+			Expect(stream.CachedInfo().Config.MaxBytes).To(Equal(int64(-1)))
 		})
 
 		It("can create stream with max age and add max bytes", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:   "test",
@@ -1231,15 +1231,15 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.MaxAge).To(Equal(1 * time.Hour))
-			Expect(info.Config.MaxBytes).To(Equal(int64(100)))
+			Expect(stream.CachedInfo().Config.MaxAge).To(Equal(1 * time.Hour))
+			Expect(stream.CachedInfo().Config.MaxBytes).To(Equal(int64(100)))
 		})
 
 		It("can create stream with max age and replace with max bytes", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:   "test",
@@ -1253,15 +1253,15 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.MaxAge).To(Equal(0 * time.Second))
-			Expect(info.Config.MaxBytes).To(Equal(int64(100)))
+			Expect(stream.CachedInfo().Config.MaxAge).To(Equal(0 * time.Second))
+			Expect(stream.CachedInfo().Config.MaxBytes).To(Equal(int64(100)))
 		})
 
 		It("can create stream with max messages and max bytes", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:     "test",
@@ -1270,15 +1270,15 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.MaxMsgs).To(Equal(int64(100)))
-			Expect(info.Config.MaxBytes).To(Equal(int64(100)))
+			Expect(stream.CachedInfo().Config.MaxMsgs).To(Equal(int64(100)))
+			Expect(stream.CachedInfo().Config.MaxBytes).To(Equal(int64(100)))
 		})
 
 		It("can update stream with max messages and max bytes", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:     "test",
@@ -1294,15 +1294,15 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.MaxMsgs).To(Equal(int64(200)))
-			Expect(info.Config.MaxBytes).To(Equal(int64(200)))
+			Expect(stream.CachedInfo().Config.MaxMsgs).To(Equal(int64(200)))
+			Expect(stream.CachedInfo().Config.MaxBytes).To(Equal(int64(200)))
 		})
 
 		It("can remove max messages and max bytes from stream", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:     "test",
@@ -1316,15 +1316,15 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.MaxMsgs).To(Equal(int64(-1)))
-			Expect(info.Config.MaxBytes).To(Equal(int64(-1)))
+			Expect(stream.CachedInfo().Config.MaxMsgs).To(Equal(int64(-1)))
+			Expect(stream.CachedInfo().Config.MaxBytes).To(Equal(int64(-1)))
 		})
 
 		It("can create stream with max messages and add max bytes", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:    "test",
@@ -1339,30 +1339,30 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.MaxMsgs).To(Equal(int64(100)))
-			Expect(info.Config.MaxBytes).To(Equal(int64(100)))
+			Expect(stream.CachedInfo().Config.MaxMsgs).To(Equal(int64(100)))
+			Expect(stream.CachedInfo().Config.MaxBytes).To(Equal(int64(100)))
 		})
 
 		Describe("Discard policies", func() {
 			It("default discard policy is old", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 					Name: "test",
 				})
 				Expect(err).ToNot(HaveOccurred())
 
-				info, err := js.StreamInfo("test")
+				stream, err := js.Stream(ctx, "test")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.Config.Discard).To(Equal(nats.DiscardOld))
+				Expect(stream.CachedInfo().Config.Discard).To(Equal(jetstream.DiscardOld))
 			})
 
 			It("can create stream with discard policy set to old", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 					Name:          "test",
@@ -1370,14 +1370,14 @@ var _ = Describe("Streams", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 
-				info, err := js.StreamInfo("test")
+				stream, err := js.Stream(ctx, "test")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.Config.Discard).To(Equal(nats.DiscardOld))
+				Expect(stream.CachedInfo().Config.Discard).To(Equal(jetstream.DiscardOld))
 			})
 
 			It("can create stream with discard policy set to new", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 					Name:          "test",
@@ -1385,14 +1385,14 @@ var _ = Describe("Streams", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 
-				info, err := js.StreamInfo("test")
+				stream, err := js.Stream(ctx, "test")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.Config.Discard).To(Equal(nats.DiscardNew))
+				Expect(stream.CachedInfo().Config.Discard).To(Equal(jetstream.DiscardNew))
 			})
 
 			It("can set discard policy to new and per subject", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 					Name: "test",
@@ -1405,15 +1405,15 @@ var _ = Describe("Streams", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 
-				info, err := js.StreamInfo("test")
+				stream, err := js.Stream(ctx, "test")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.Config.Discard).To(Equal(nats.DiscardNew))
-				Expect(info.Config.DiscardNewPerSubject).To(BeTrue())
+				Expect(stream.CachedInfo().Config.Discard).To(Equal(jetstream.DiscardNew))
+				Expect(stream.CachedInfo().Config.DiscardNewPerSubject).To(BeTrue())
 			})
 
 			It("can update discard policy", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 					Name:          "test",
@@ -1427,14 +1427,14 @@ var _ = Describe("Streams", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 
-				info, err := js.StreamInfo("test")
+				stream, err := js.Stream(ctx, "test")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(info.Config.Discard).To(Equal(nats.DiscardOld))
+				Expect(stream.CachedInfo().Config.Discard).To(Equal(jetstream.DiscardOld))
 			})
 
 			It("setting discard policy to new per subject fails if no max messages per subject", func(ctx context.Context) {
-				_, err := js.StreamInfo("test")
-				Expect(err).To(MatchError(nats.ErrStreamNotFound))
+				_, err := js.Stream(ctx, "test")
+				Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 				_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 					Name: "test",
@@ -1451,22 +1451,22 @@ var _ = Describe("Streams", func() {
 
 	Describe("Storage", func() {
 		It("defaults to file storage", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name: "test",
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.Storage).To(Equal(nats.FileStorage))
+			Expect(stream.CachedInfo().Config.Storage).To(Equal(jetstream.FileStorage))
 		})
 
 		It("can create stream with file storage", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:        "test",
@@ -1474,14 +1474,14 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.Storage).To(Equal(nats.FileStorage))
+			Expect(stream.CachedInfo().Config.Storage).To(Equal(jetstream.FileStorage))
 		})
 
 		It("can create stream with memory storage", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:        "test",
@@ -1489,14 +1489,14 @@ var _ = Describe("Streams", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			info, err := js.StreamInfo("test")
+			stream, err := js.Stream(ctx, "test")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(info.Config.Storage).To(Equal(nats.MemoryStorage))
+			Expect(stream.CachedInfo().Config.Storage).To(Equal(jetstream.MemoryStorage))
 		})
 
 		It("updating storage type of existing stream errors", func(ctx context.Context) {
-			_, err := js.StreamInfo("test")
-			Expect(err).To(MatchError(nats.ErrStreamNotFound))
+			_, err := js.Stream(ctx, "test")
+			Expect(err).To(MatchError(jetstream.ErrStreamNotFound))
 
 			_, err = manager.EnsureStream(ctx, &events.StreamConfig{
 				Name:        "test",


### PR DESCRIPTION
This change upgrades nats.go and switches to the new JetStream API. This once again changes how flow control is handled, as the new API is slightly different when it comes to fetching messages.